### PR TITLE
Add touchstart to list of watched events

### DIFF
--- a/src/keypad-class.js
+++ b/src/keypad-class.js
@@ -281,12 +281,13 @@ export default function (Framework7Class) {
           if (button.onClick) {
             button.onClick(keypad, button);
           }
+          e.preventDefault();
         }
 
-        $buttonsEl.on('click', handleClick);
+        $buttonsEl.on('touchstart click', handleClick);
 
         keypad.detachKeypadEvents = function detachKeypadEvents() {
-          $buttonsEl.off('click', handleClick);
+          $buttonsEl.off('touchstart click', handleClick);
         };
       };
 


### PR DESCRIPTION
On Mobile Safari, the click event is not being fired for all touches to the keypad buttons. By responding to touchstart rather than click, all of the events are sent to the keypad buttons. 