### PR TITLE
Не вызывать событие change если фактически ничего не меняется

### DIFF
--- a/src/keypad-class.js
+++ b/src/keypad-class.js
@@ -498,11 +498,12 @@ export default function (Framework7Class) {
       keypad.value = newValue;
       if (keypad.params.valueMaxLength && keypad.value.length > keypad.params.valueMaxLength) {
         keypad.value = keypad.value.substring(0, keypad.params.valueMaxLength);
-      }
-      keypad.emit('local::change keypadChange', keypad, keypad.value);
-      if (keypad.$inputEl && keypad.$inputEl.length > 0) {
-        keypad.$inputEl.val(keypad.formatValue(keypad.value));
-        keypad.$inputEl.trigger('change');
+      } else {
+        keypad.emit('local::change keypadChange', keypad, keypad.value);
+        if (keypad.$inputEl && keypad.$inputEl.length > 0) {
+          keypad.$inputEl.val(keypad.formatValue(keypad.value));
+          keypad.$inputEl.trigger('change');
+        }
       }
     }
 


### PR DESCRIPTION
Если мы установили клавиатуре макс. к-во цифр: valueMaxLength, то после того, как ввели все и жмем еще на кнопку, событие change будет вызываться, хотя по факт изменений никаких вообще не будет.