### PR TITLE
Remove gap from CSP

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#2196f3">
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data:">
   <title>Framework7 Keypad</title>
   <link rel="stylesheet" href="https://unpkg.com/framework7/framework7-bundle.min.css">
 </head>


### PR DESCRIPTION
In the latest release of Cordova CLI 11.0.0 the latest App Hello World template 6.0.0 is used for all new projects, in which the `gap:` (which was needed when using UIWebView on iOS) from the Content Security Policy has been completely removed.

So I thought of making the same change in framework7-plugin-keypad index.html file.